### PR TITLE
Add auto-advance timer UI and countdown styling

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -3,7 +3,7 @@ VITE_NAKAMA_HOST=127.0.0.1
 VITE_NAKAMA_PORT=7350
 VITE_NAKAMA_SERVER_KEY=defaultkey
 VITE_NAKAMA_SSL=false
-ROUND_TIME_OFFSET_MINUTES=60
+VITE_ROUND_TIME_OFFSET_MINUTES=60
 
 # Production settings (uncomment and configure for deployment)
 # VITE_NAKAMA_HOST=your-nakama-server.com

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -967,7 +967,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1134,7 +1133,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1448,7 +1446,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2770,7 +2767,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/client/src/env.d.ts
+++ b/client/src/env.d.ts
@@ -5,7 +5,7 @@ interface ImportMetaEnv {
     readonly VITE_NAKAMA_PORT: string
     readonly VITE_NAKAMA_SERVER_KEY: string
     readonly VITE_NAKAMA_SSL: string
-    readonly ROUND_TIME_OFFSET_MINUTES: string
+    readonly VITE_ROUND_TIME_OFFSET_MINUTES: string
 }
 
 interface ImportMeta {

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -904,13 +904,8 @@ export class GameScene extends Phaser.Scene {
     const totalMinutes = Math.max(0, Math.ceil(diffMs / 60_000));
     const hours = Math.floor(totalMinutes / 60);
     const minutes = totalMinutes % 60;
-    const targetLabel = `${String(parsed.hours).padStart(2, "0")}:${String(
-      parsed.minutes,
-    ).padStart(2, "0")}`;
-    this.autoAdvanceText.setText(
-      `Auto-advance at ${targetLabel} • ${hours}h ${minutes}m`,
-    );
-    const urgent = diffMs <= 3 * 60 * 60 * 1000;
+    this.autoAdvanceText.setText(`Auto-advance in ${hours}h ${minutes}m`);
+    const urgent = diffMs < 3 * 60 * 60 * 1000;
     this.autoAdvanceText.setColor(urgent ? "#ff6666" : "#cbd5f5");
   }
 

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -91,6 +91,10 @@ export class GameScene extends Phaser.Scene {
   private tileItemContainers = new Map<string, Phaser.GameObjects.Container>();
   private itemTooltip: ItemTooltipManager | null = null;
   private topBanner: TopBanner | null = null;
+  private autoAdvanceText: Phaser.GameObjects.Text | null = null;
+  private autoAdvanceTimer: Phaser.Time.TimerEvent | null = null;
+  private autoAdvanceEnabled = false;
+  private autoAdvanceRoundTime: string | null = null;
   private chatService: MatchChatService | null = null;
   private chatMessages: MatchChatMessage[] = [];
   private chatUnsubscribe: (() => void) | null = null;
@@ -243,6 +247,16 @@ export class GameScene extends Phaser.Scene {
       camera: this.cam,
     });
 
+    this.autoAdvanceText = this.add
+      .text(10, 10, "", {
+        fontFamily: "Arial",
+        fontSize: "14px",
+        color: "#cbd5f5",
+      })
+      .setScrollFactor(0)
+      .setVisible(false);
+    this.cam.ignore(this.autoAdvanceText);
+
     const match = await this.fetchMatchFromServer();
     this.currentMatch = match;
     this.logReplayCache.clear();
@@ -262,6 +276,7 @@ export class GameScene extends Phaser.Scene {
       this.renderPlayerCharacters(match);
     }
     this.updateCharacterPanel(match);
+    this.configureAutoAdvanceTimer(match);
 
     this.enableDragPan();
     this.enableWheelZoom();
@@ -332,6 +347,12 @@ export class GameScene extends Phaser.Scene {
       }
       this.topBanner?.destroy();
       this.topBanner = null;
+      if (this.autoAdvanceTimer) {
+        this.autoAdvanceTimer.remove(false);
+        this.autoAdvanceTimer = null;
+      }
+      this.autoAdvanceText?.destroy();
+      this.autoAdvanceText = null;
       if (this.chatUnsubscribe) {
         this.chatUnsubscribe();
         this.chatUnsubscribe = null;
@@ -831,6 +852,82 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
+  private configureAutoAdvanceTimer(match: MatchRecord | null) {
+    const roundTime =
+      match && typeof match.roundTime === "string" ? match.roundTime : null;
+    const autoSkip = match?.autoSkip === true;
+    this.autoAdvanceEnabled = autoSkip && !!roundTime;
+    this.autoAdvanceRoundTime = this.autoAdvanceEnabled ? roundTime : null;
+
+    if (!this.autoAdvanceText) {
+      return;
+    }
+
+    if (!this.autoAdvanceEnabled || !this.autoAdvanceRoundTime) {
+      this.autoAdvanceText.setVisible(false);
+      if (this.autoAdvanceTimer) {
+        this.autoAdvanceTimer.remove(false);
+        this.autoAdvanceTimer = null;
+      }
+      return;
+    }
+
+    this.autoAdvanceText.setVisible(true);
+    this.refreshAutoAdvanceTimer();
+
+    if (!this.autoAdvanceTimer) {
+      this.autoAdvanceTimer = this.time.addEvent({
+        delay: 60_000,
+        loop: true,
+        callback: this.refreshAutoAdvanceTimer,
+        callbackScope: this,
+      });
+    }
+  }
+
+  private refreshAutoAdvanceTimer() {
+    if (!this.autoAdvanceText || !this.autoAdvanceRoundTime) {
+      return;
+    }
+    const parsed = this.parseRoundTime(this.autoAdvanceRoundTime);
+    if (!parsed) {
+      this.autoAdvanceText.setText("Auto-advance time unavailable");
+      return;
+    }
+    const now = new Date();
+    const target = new Date(now);
+    target.setHours(parsed.hours, parsed.minutes, 0, 0);
+    if (target.getTime() <= now.getTime()) {
+      target.setDate(target.getDate() + 1);
+    }
+    const diffMs = target.getTime() - now.getTime();
+    const totalMinutes = Math.max(0, Math.ceil(diffMs / 60_000));
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    const targetLabel = `${String(parsed.hours).padStart(2, "0")}:${String(
+      parsed.minutes,
+    ).padStart(2, "0")}`;
+    this.autoAdvanceText.setText(
+      `Auto-advance at ${targetLabel} • ${hours}h ${minutes}m`,
+    );
+    const urgent = diffMs <= 3 * 60 * 60 * 1000;
+    this.autoAdvanceText.setColor(urgent ? "#ff6666" : "#cbd5f5");
+  }
+
+  private parseRoundTime(value: string): { hours: number; minutes: number } | null {
+    const parts = value.split(":");
+    if (parts.length !== 2) return null;
+    const hours = Number(parts[0]);
+    const minutes = Number(parts[1]);
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+      return null;
+    }
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+      return null;
+    }
+    return { hours, minutes };
+  }
+
   private layoutUI() {
     const width = this.uiCam ? this.uiCam.width : this.scale.width;
     const height = this.uiCam ? this.uiCam.height : this.scale.height;
@@ -841,6 +938,9 @@ export class GameScene extends Phaser.Scene {
     }
     if (this.menuButton) {
       this.menuButton.setPosition(0 + 10, height - this.menuButton.height - 10);
+    }
+    if (this.autoAdvanceText) {
+      this.autoAdvanceText.setPosition(10, 10);
     }
     this.topBanner?.layout(width);
   }
@@ -1434,6 +1534,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.updateCharacterPanel(match);
+    this.configureAutoAdvanceTimer(match);
     if (this.characterPanel) {
       this.characterPanel.setLogTurnInfo(match.current_turn ?? 0);
     }

--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -95,6 +95,8 @@ export class GameScene extends Phaser.Scene {
   private autoAdvanceTimer: Phaser.Time.TimerEvent | null = null;
   private autoAdvanceEnabled = false;
   private autoAdvanceRoundTime: string | null = null;
+  private autoAdvanceOffsetMinutes = 0;
+  private autoAdvanceLastAt: number | undefined = undefined;
   private chatService: MatchChatService | null = null;
   private chatMessages: MatchChatMessage[] = [];
   private chatUnsubscribe: (() => void) | null = null;
@@ -858,6 +860,11 @@ export class GameScene extends Phaser.Scene {
     const autoSkip = match?.autoSkip === true;
     this.autoAdvanceEnabled = autoSkip && !!roundTime;
     this.autoAdvanceRoundTime = this.autoAdvanceEnabled ? roundTime : null;
+    this.autoAdvanceLastAt = match?.lastAutoAdvanceAt;
+
+    const rawOffset = import.meta.env.VITE_ROUND_TIME_OFFSET_MINUTES;
+    const parsedOffset = rawOffset ? parseInt(rawOffset, 10) : 0;
+    this.autoAdvanceOffsetMinutes = isFinite(parsedOffset) ? parsedOffset : 0;
 
     if (!this.autoAdvanceText) {
       return;
@@ -894,19 +901,46 @@ export class GameScene extends Phaser.Scene {
       this.autoAdvanceText.setText("Auto-advance time unavailable");
       return;
     }
-    const now = new Date();
-    const target = new Date(now);
-    target.setHours(parsed.hours, parsed.minutes, 0, 0);
-    if (target.getTime() <= now.getTime()) {
-      target.setDate(target.getDate() + 1);
-    }
-    const diffMs = target.getTime() - now.getTime();
+    const targetMinutes = parsed.hours * 60 + parsed.minutes;
+    const nowMs = Date.now();
+    const offsetMs = this.autoAdvanceOffsetMinutes * 60_000;
+    const nowLocal = new Date(nowMs + offsetMs);
+    const localMidnightMs =
+      Date.UTC(
+        nowLocal.getUTCFullYear(),
+        nowLocal.getUTCMonth(),
+        nowLocal.getUTCDate(),
+      ) - offsetMs;
+    const targetTodayMs = localMidnightMs + targetMinutes * 60_000;
+
+    const lastAt = this.autoAdvanceLastAt;
+    const alreadyAdvancedToday =
+      lastAt !== undefined &&
+      this.isInSameLocalDay(lastAt * 1000, nowMs);
+
+    const nextTargetMs =
+      alreadyAdvancedToday || nowMs >= targetTodayMs
+        ? targetTodayMs + 24 * 60 * 60_000
+        : targetTodayMs;
+
+    const diffMs = nextTargetMs - nowMs;
     const totalMinutes = Math.max(0, Math.ceil(diffMs / 60_000));
     const hours = Math.floor(totalMinutes / 60);
     const minutes = totalMinutes % 60;
     this.autoAdvanceText.setText(`Auto-advance in ${hours}h ${minutes}m`);
-    const urgent = diffMs < 3 * 60 * 60 * 1000;
+    const urgent = diffMs < 3 * 60 * 60_000;
     this.autoAdvanceText.setColor(urgent ? "#ff6666" : "#cbd5f5");
+  }
+
+  private isInSameLocalDay(msA: number, msB: number): boolean {
+    const offsetMs = this.autoAdvanceOffsetMinutes * 60_000;
+    const dateA = new Date(msA + offsetMs);
+    const dateB = new Date(msB + offsetMs);
+    return (
+      dateA.getUTCFullYear() === dateB.getUTCFullYear() &&
+      dateA.getUTCMonth() === dateB.getUTCMonth() &&
+      dateA.getUTCDate() === dateB.getUTCDate()
+    );
   }
 
   private parseRoundTime(value: string): { hours: number; minutes: number } | null {


### PR DESCRIPTION
This pull request adds an auto-advance timer feature to the `GameScene` in `client/src/scenes/GameScene.ts`, which displays a countdown until the next automatic round advancement. The implementation introduces UI elements, timer management, and logic to calculate and display the time remaining, with visual urgency cues when the timer is close to expiring.

**Auto-advance timer feature:**

* Added new properties to `GameScene` for managing the auto-advance timer and its display text, including `autoAdvanceText`, `autoAdvanceTimer`, and relevant state flags.
* Implemented the `configureAutoAdvanceTimer` method to initialize, update, and clean up the auto-advance timer and its UI, based on match settings.
* Created the `refreshAutoAdvanceTimer` and `parseRoundTime` helper methods to calculate and show the remaining time until auto-advance, including color changes for urgency.

**UI integration and cleanup:**

* Added the `autoAdvanceText` UI element to the scene and ensured it is positioned and updated correctly during layout changes. [[1]](diffhunk://#diff-04371ce35f6690bfe4bec31ac95b40e856cf36a21cd74be6677bc4320e3841bbR250-R259) [[2]](diffhunk://#diff-04371ce35f6690bfe4bec31ac95b40e856cf36a21cd74be6677bc4320e3841bbR937-R939)
* Ensured proper cleanup of the auto-advance timer and UI element when the scene is destroyed.

**Game logic integration:**

* Called `configureAutoAdvanceTimer` after fetching and updating match data to ensure the timer reflects the latest match state. [[1]](diffhunk://#diff-04371ce35f6690bfe4bec31ac95b40e856cf36a21cd74be6677bc4320e3841bbR279) [[2]](diffhunk://#diff-04371ce35f6690bfe4bec31ac95b40e856cf36a21cd74be6677bc4320e3841bbR1532)