### PR TITLE
Show winner banner and dance animation

### DIFF
--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -823,12 +823,42 @@ export class GameScene extends Phaser.Scene {
     if (!matchId || payload.match_id !== matchId) {
       return;
     }
-    if (!this.currentUserId) {
+    const winnerId = payload.winnerId;
+    const winnerName = winnerId
+      ? this.playerNameMap[winnerId] ?? "Unknown"
+      : "No winner";
+    const bannerText = winnerId
+      ? `Winner: ${winnerName}`
+      : "Match ended";
+    this.topBanner?.show({ text: bannerText });
+    if (winnerId) {
+      this.playWinnerDance(winnerId);
+    }
+  }
+
+  private playWinnerDance(winnerId: string) {
+    const sprite = this.playerSprites.get(winnerId);
+    if (!sprite || !sprite.active) {
       return;
     }
-    if (payload.winnerId && payload.winnerId !== this.currentUserId) {
-      this.topBanner?.show({ text: "You lost the match." });
-    }
+    const startY = sprite.y;
+    this.tweens.add({
+      targets: sprite,
+      y: startY - 8,
+      duration: 180,
+      ease: "Sine.easeInOut",
+      yoyo: true,
+      repeat: 5,
+    });
+    this.tweens.add({
+      targets: sprite,
+      angle: { from: -6, to: 6 },
+      duration: 180,
+      ease: "Sine.easeInOut",
+      yoyo: true,
+      repeat: 5,
+      onComplete: () => sprite.setAngle(0),
+    });
   }
 
   private layoutUI() {


### PR DESCRIPTION
This pull request enhances the end-of-match experience in the `GameScene` by improving how the winner is displayed and adding a celebratory animation for the winning player. The changes focus on user feedback and visual polish when a match concludes.

Improvements to match end feedback:

* The winner's name is now shown in the top banner at the end of a match, defaulting to "Unknown" if the name cannot be found or "No winner" if there is no winner.

Visual effects for the winner:

* Added a new `playWinnerDance` method that animates the winning player's sprite with a bouncing and rotating effect to celebrate their victory. This animation is triggered only for the winner at the end of the match.