### PR TITLE
fix: notify clients when host removes game

### DIFF
--- a/client/src/scenes/MainScene.ts
+++ b/client/src/scenes/MainScene.ts
@@ -227,6 +227,12 @@ export class MainScene extends Phaser.Scene {
         this.statusText.setText(
           "Match has been removed by the host. Returning to main menu.",
         );
+        if (this.scene.isActive("GameScene") || this.scene.isSleeping("GameScene")) {
+          this.scene.stop("GameScene");
+        }
+        if (this.scene.isSleeping("MainScene")) {
+          this.scene.wake("MainScene");
+        }
         if (this.currentMatchId && this.turnService) {
           this.turnService
             .leaveRealtimeMatch(this.currentMatchId)


### PR DESCRIPTION
## Planned issue
When the host removes the game, clients are not notified and stay in a broken state.

## Scope for later implementation
- Send a clear server event when host removes the game
- Handle client-side cleanup and UI transition
- Prevent stale/broken session state

## Status
Planning PR only. No implementation in this branch yet.