### PR TITLE
fix: gui panel interactions and actions selector input bugs

### DIFF
--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -790,7 +790,7 @@ export class GameScene extends Phaser.Scene {
     // No-op handlers removed
 
     this.input.on("pointermove", (p: Phaser.Input.Pointer) => {
-      if (!p.isDown || this.pointerDownInUI) return;
+      if (!p.isDown || this.pointerDownInUI || this.gridModalActive) return;
 
       // const { x, y } = p.velocity; // camStart.x - dx
       const diffX = p.position.x - p.prevPosition.x;
@@ -1124,6 +1124,7 @@ export class GameScene extends Phaser.Scene {
       return;
     }
     this.characterPanel.appendChatMessage(this.toChatViewModel(message));
+    this.characterPanel.markChatUnread(true);
   }
 
   private syncChatMessagesToPanel() {

--- a/client/src/ui/CharacterPanel.ts
+++ b/client/src/ui/CharacterPanel.ts
@@ -213,6 +213,19 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
     }
     this.setReadyState(!this.readyState, true);
   };
+  private readyPointerIsDown = false;
+  private readonly handleReadyPointerDown = () => {
+    this.readyPointerIsDown = true;
+  };
+  private readonly handleReadyPointerOut = () => {
+    this.readyPointerIsDown = false;
+  };
+  private readonly handleReadyPointerUp = () => {
+    if (this.readyPointerIsDown) {
+      this.readyPointerIsDown = false;
+      this.handleReadyToggle();
+    }
+  };
   private readonly handleSecondaryActionSelection = (
     actionId: string | null,
   ) => {
@@ -398,19 +411,9 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
       })
       .setOrigin(0, 0);
     this.readyToggle.setInteractive({ useHandCursor: true });
-    let readyPointerIsDown = false;
-    this.readyToggle.on(Phaser.Input.Events.POINTER_DOWN, () => {
-      readyPointerIsDown = true;
-    });
-    this.readyToggle.on(Phaser.Input.Events.POINTER_OUT, () => {
-      readyPointerIsDown = false;
-    });
-    this.readyToggle.on(Phaser.Input.Events.POINTER_UP, () => {
-      if (readyPointerIsDown) {
-        readyPointerIsDown = false;
-        this.handleReadyToggle();
-      }
-    });
+    this.readyToggle.on(Phaser.Input.Events.POINTER_DOWN, this.handleReadyPointerDown);
+    this.readyToggle.on(Phaser.Input.Events.POINTER_OUT, this.handleReadyPointerOut);
+    this.readyToggle.on(Phaser.Input.Events.POINTER_UP, this.handleReadyPointerUp);
     this.add(this.readyToggle);
     this.setReadyEnabled(false);
 
@@ -867,9 +870,9 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
       this.handleSecondaryPlayerSelection,
     );
     this.secondaryPlayerSelector.hideDropdown();
-    this.readyToggle?.off(Phaser.Input.Events.POINTER_DOWN);
-    this.readyToggle?.off(Phaser.Input.Events.POINTER_OUT);
-    this.readyToggle?.off(Phaser.Input.Events.POINTER_UP);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_DOWN, this.handleReadyPointerDown);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_OUT, this.handleReadyPointerOut);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_UP, this.handleReadyPointerUp);
     this.logView?.destroy();
     this.chatView?.destroy();
     this.scrollPanel?.clearMask?.();

--- a/client/src/ui/CharacterPanel.ts
+++ b/client/src/ui/CharacterPanel.ts
@@ -323,6 +323,16 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
         })
         .setOrigin(0, 0)
         .setInteractive({ useHandCursor: true });
+      const badge = scene.add
+        .rectangle(
+          index * tabWidth + tabWidth - 10,
+          6,
+          8,
+          8,
+          0xff6600,
+        )
+        .setOrigin(0.5, 0)
+        .setVisible(false);
       rect.on(Phaser.Input.Events.POINTER_UP, () => {
         this.handleTabRequest(tab.key as TabKey);
       });
@@ -331,7 +341,8 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
       });
       this.add(rect);
       this.add(text);
-      this.tabs.push({ key: tab.key as TabKey, rect, text });
+      this.add(badge);
+      this.tabs.push({ key: tab.key as TabKey, rect, text, badge });
     });
     const contentTop = TAB_HEIGHT + MARGIN;
     const portraitScale = PORTRAIT_SIZE / 16;
@@ -387,7 +398,19 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
       })
       .setOrigin(0, 0);
     this.readyToggle.setInteractive({ useHandCursor: true });
-    this.readyToggle.on("pointerup", this.handleReadyToggle);
+    let readyPointerIsDown = false;
+    this.readyToggle.on(Phaser.Input.Events.POINTER_DOWN, () => {
+      readyPointerIsDown = true;
+    });
+    this.readyToggle.on(Phaser.Input.Events.POINTER_OUT, () => {
+      readyPointerIsDown = false;
+    });
+    this.readyToggle.on(Phaser.Input.Events.POINTER_UP, () => {
+      if (readyPointerIsDown) {
+        readyPointerIsDown = false;
+        this.handleReadyToggle();
+      }
+    });
     this.add(this.readyToggle);
     this.setReadyEnabled(false);
 
@@ -433,7 +456,7 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
         pointerOutRelease: true,
       },
       mouseWheelScroller: {
-        focus: false,
+        focus: true,
         speed: 0.35,
       },
       space: { left: 0, right: 0, top: 0, bottom: 0 },
@@ -784,6 +807,7 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
         this.inventoryGrid.setActive(false);
       },
       onChatTabShow: () => {
+        this.tabsController.setTabUnread("chat", false);
         this.chatView.handleVisibilityChange(true);
         this.emit("chat-tab-opened");
       },
@@ -843,7 +867,9 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
       this.handleSecondaryPlayerSelection,
     );
     this.secondaryPlayerSelector.hideDropdown();
-    this.readyToggle?.off("pointerup", this.handleReadyToggle);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_DOWN);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_OUT);
+    this.readyToggle?.off(Phaser.Input.Events.POINTER_UP);
     this.logView?.destroy();
     this.chatView?.destroy();
     this.scrollPanel?.clearMask?.();
@@ -931,6 +957,13 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
 
   appendChatMessage(message: ChatMessageViewModel) {
     this.chatView?.appendMessage(message);
+  }
+
+  markChatUnread(unread: boolean) {
+    if (unread && this.tabsController?.getActiveTab() === "chat") {
+      return;
+    }
+    this.tabsController?.setTabUnread("chat", unread);
   }
 
   setChatConnectionState(state: ChatConnectionState, message?: string) {

--- a/client/src/ui/CharacterPanelTabs.ts
+++ b/client/src/ui/CharacterPanelTabs.ts
@@ -6,6 +6,7 @@ export interface CharacterPanelTabEntry {
   key: TabKey;
   rect: Phaser.GameObjects.Rectangle;
   text: Phaser.GameObjects.Text;
+  badge?: Phaser.GameObjects.Rectangle;
 }
 
 interface CharacterPanelTabsOptions {
@@ -31,6 +32,7 @@ interface CharacterPanelTabsOptions {
 
 export class CharacterPanelTabs {
   private activeKey: TabKey;
+  private readonly unreadTabs = new Set<TabKey>();
 
   constructor(private readonly options: CharacterPanelTabsOptions) {
     this.activeKey = options.defaultKey;
@@ -42,6 +44,15 @@ export class CharacterPanelTabs {
 
   isActive(key: TabKey): boolean {
     return this.activeKey === key;
+  }
+
+  setTabUnread(key: TabKey, unread: boolean): void {
+    if (unread) {
+      this.unreadTabs.add(key);
+    } else {
+      this.unreadTabs.delete(key);
+    }
+    this.updateStyles();
   }
 
   setActiveTab(key: TabKey): void {
@@ -56,6 +67,7 @@ export class CharacterPanelTabs {
     }
     const previous = this.activeKey;
     this.activeKey = key;
+    this.unreadTabs.delete(key);
     this.updateStyles();
     this.updateVisibility(false);
     this.options.onTabChange(key, previous);
@@ -75,8 +87,12 @@ export class CharacterPanelTabs {
   private updateStyles(): void {
     for (const tab of this.options.tabs) {
       const active = tab.key === this.activeKey;
+      const unread = !active && this.unreadTabs.has(tab.key);
       tab.rect.setFillStyle(active ? 0x253055 : 0x1c233f);
       tab.text.setAlpha(active ? 1 : 0.7);
+      if (tab.badge) {
+        tab.badge.setVisible(unread);
+      }
     }
   }
 

--- a/client/src/ui/GridSelect.ts
+++ b/client/src/ui/GridSelect.ts
@@ -51,7 +51,7 @@ type RexSizer = Phaser.GameObjects.GameObject & {
     proportion?: number,
     align?: string,
     padding?: number | Record<string, number>,
-    expand?: boolean
+    expand?: boolean,
   ) => unknown;
   addBackground: (background: Phaser.GameObjects.GameObject) => unknown;
   layout: () => unknown;
@@ -68,11 +68,11 @@ type RexGridTable = Phaser.GameObjects.GameObject & {
   on: (
     event: string,
     callback: (...args: unknown[]) => void,
-    context?: unknown
+    context?: unknown,
   ) => unknown;
   resetAllCellsSize?: (width: number, height: number) => unknown;
   setMask?: (
-    mask: Phaser.Display.Masks.BitmapMask | Phaser.Display.Masks.GeometryMask
+    mask: Phaser.Display.Masks.BitmapMask | Phaser.Display.Masks.GeometryMask,
   ) => Phaser.GameObjects.GameObject;
   clearMask?: (destroyMask?: boolean) => Phaser.GameObjects.GameObject;
 };
@@ -82,7 +82,7 @@ type RexRoundRectangle = Phaser.GameObjects.GameObject & {
   setStrokeStyle?: (
     lineWidth: number,
     color?: number,
-    alpha?: number
+    alpha?: number,
   ) => unknown;
   setSize?: (width: number, height: number) => unknown;
   setDisplaySize?: (width: number, height: number) => unknown;
@@ -123,7 +123,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     scene: Phaser.Scene,
     x: number,
     y: number,
-    config: GridSelectConfig
+    config: GridSelectConfig,
   ) {
     super(scene, x, y);
     scene.add.existing(this);
@@ -163,7 +163,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       .setOrigin(0, 0)
       .setInteractive(
         new Phaser.Geom.Rectangle(0, 0, config.width, this.collapsedHeight),
-        Phaser.Geom.Rectangle.Contains
+        Phaser.Geom.Rectangle.Contains,
       );
 
     this.background = scene.rexUI.add.roundRectangle(
@@ -172,7 +172,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       config.width,
       this.collapsedHeight,
       10,
-      COLLAPSED_BACKGROUND_COLOR
+      COLLAPSED_BACKGROUND_COLOR,
     ) as RexRoundRectangle;
     this.background.setOrigin?.(0, 0);
     this.background.setStrokeStyle?.(2, COLLAPSED_BORDER_COLOR, 1);
@@ -181,7 +181,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       12,
       this.collapsedHeight / 2,
       "hex",
-      "grass_01.png"
+      "grass_01.png",
     );
     this.icon.setOrigin(0, 0.5);
     this.icon.setDisplaySize(this.iconTargetSize, this.iconTargetSize);
@@ -194,7 +194,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         {
           fontSize: "17px",
           color: this.labelActiveColor,
-        }
+        },
       )
       .setOrigin(0, 0.5);
 
@@ -243,7 +243,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     const currentId = this.selectedItem?.id ?? null;
     if (currentId) {
       const current = this.items.find(
-        (it) => it.id === currentId && it.disabled !== true
+        (it) => it.id === currentId && it.disabled !== true,
       );
       if (current) {
         this.applySelection(current, false);
@@ -356,7 +356,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
   private selectFirstAvailable(emit: boolean) {
     let first =
       this.items.find(
-        (it) => it.disabled !== true && it.isEmptyOption !== true
+        (it) => it.disabled !== true && it.isEmptyOption !== true,
       ) ?? null;
     if (!first) {
       first =
@@ -402,7 +402,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       const scale = Phaser.Math.Clamp(item.iconScale ?? 1, 0.1, 4);
       this.icon.setDisplaySize(
         this.iconTargetSize * scale,
-        this.iconTargetSize * scale
+        this.iconTargetSize * scale,
       );
       this.icon.setVisible(true);
     } else {
@@ -456,11 +456,11 @@ export class GridSelect extends Phaser.GameObjects.Container {
         _pointer: Phaser.Input.Pointer,
         _x: number,
         _y: number,
-        event: Phaser.Types.Input.EventData
+        event: Phaser.Types.Input.EventData,
       ) => {
         pointerDownOnCover = true;
         event.stopPropagation();
-      }
+      },
     );
     cover.on(
       Phaser.Input.Events.POINTER_MOVE,
@@ -468,10 +468,10 @@ export class GridSelect extends Phaser.GameObjects.Container {
         _pointer: Phaser.Input.Pointer,
         _x: number,
         _y: number,
-        event: Phaser.Types.Input.EventData
+        event: Phaser.Types.Input.EventData,
       ) => {
         event.stopPropagation();
-      }
+      },
     );
     cover.on(
       Phaser.Input.Events.POINTER_UP,
@@ -479,7 +479,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         _pointer: Phaser.Input.Pointer,
         _x: number,
         _y: number,
-        event: Phaser.Types.Input.EventData
+        event: Phaser.Types.Input.EventData,
       ) => {
         event.stopPropagation();
         if (!pointerDownOnCover) {
@@ -488,7 +488,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         pointerDownOnCover = false;
         this.tooltip?.hide();
         this.closeModal();
-      }
+      },
     );
     cover.on(
       "wheel",
@@ -497,10 +497,10 @@ export class GridSelect extends Phaser.GameObjects.Container {
         _dx: number,
         _dy: number,
         _dz: number,
-        event: WheelEvent
+        event: WheelEvent,
       ) => {
         event.stopPropagation();
-      }
+      },
     );
     overlay.add(cover);
 
@@ -517,22 +517,32 @@ export class GridSelect extends Phaser.GameObjects.Container {
       this.modalWidth,
       this.modalHeight,
       14,
-      MODAL_BACKGROUND_COLOR
+      MODAL_BACKGROUND_COLOR,
     );
     modal.addBackground(background);
     const backgroundGO = background as unknown as Phaser.GameObjects.GameObject;
     backgroundGO.setInteractive();
     backgroundGO.on(
       Phaser.Input.Events.POINTER_DOWN,
-      (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: Phaser.Types.Input.EventData) => {
+      (
+        _pointer: Phaser.Input.Pointer,
+        _x: number,
+        _y: number,
+        event: Phaser.Types.Input.EventData,
+      ) => {
         event.stopPropagation();
-      }
+      },
     );
     backgroundGO.on(
       Phaser.Input.Events.POINTER_UP,
-      (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: Phaser.Types.Input.EventData) => {
+      (
+        _pointer: Phaser.Input.Pointer,
+        _x: number,
+        _y: number,
+        event: Phaser.Types.Input.EventData,
+      ) => {
         event.stopPropagation();
-      }
+      },
     );
 
     const header = scene.add
@@ -558,7 +568,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       1,
       "center",
       0,
-      true
+      true,
     );
 
     modal.layout();
@@ -576,7 +586,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         (gridTable as unknown as { x?: number }).x ?? 0,
         (gridTable as unknown as { y?: number }).y ?? 0,
         (gridTable as unknown as { width?: number }).width ?? 0,
-        (gridTable as unknown as { height?: number }).height ?? 0
+        (gridTable as unknown as { height?: number }).height ?? 0,
       );
     this.gridTableMaskShape = scene.add
       .rectangle(bounds.x, bounds.y, bounds.width, bounds.height, 0xffffff, 1)
@@ -660,7 +670,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       },
       mouseWheelScroller: {
         focus: true,
-        speed: 1.5,
+        speed: 1,
       },
       space: {
         left: 0,
@@ -677,7 +687,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
           height: number;
           item: GridSelectItem;
         },
-        cellContainer: Phaser.GameObjects.GameObject | undefined
+        cellContainer: Phaser.GameObjects.GameObject | undefined,
       ) => this.buildCellContainer(cell, cellContainer),
     }) as RexGridTable;
 
@@ -695,7 +705,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         this.applySelection(item, true);
         this.closeModal();
       },
-      this
+      this,
     );
 
     gridTable.on(
@@ -709,7 +719,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         this.applySelection(item, true);
         this.closeModal();
       },
-      this
+      this,
     );
 
     gridTable.on(
@@ -717,7 +727,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       (
         cellContainer: Phaser.GameObjects.GameObject,
         cellIndex: number,
-        pointer?: Phaser.Input.Pointer
+        pointer?: Phaser.Input.Pointer,
       ) => {
         if (!pointer) {
           return;
@@ -761,7 +771,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
           body: tooltipBody,
         });
       },
-      this
+      this,
     );
 
     gridTable.on(
@@ -769,7 +779,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       () => {
         this.tooltip?.hide();
       },
-      this
+      this,
     );
 
     return gridTable;
@@ -782,7 +792,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       height: number;
       item: GridSelectItem;
     },
-    existing: Phaser.GameObjects.GameObject | undefined
+    existing: Phaser.GameObjects.GameObject | undefined,
   ) {
     const scene = this.scene;
     const item = cell.item;
@@ -812,7 +822,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         cellWidth,
         cellHeight,
         12,
-        CARD_BACKGROUND_COLOR
+        CARD_BACKGROUND_COLOR,
       ) as RexRoundRectangle;
       bg.setSize?.(cellWidth, cellHeight);
       bg.setDisplaySize?.(cellWidth, cellHeight);
@@ -831,7 +841,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         const maxIconSize = this.resolveMaxIconDimension(cellHeight);
         const resolvedIconSize = Math.min(
           baseIconSize * iconScale,
-          maxIconSize
+          maxIconSize,
         );
         icon.setDisplaySize(resolvedIconSize, resolvedIconSize);
         icon.setActive(true);
@@ -879,13 +889,13 @@ export class GridSelect extends Phaser.GameObjects.Container {
       const nameTruncated = this.applySingleLineText(
         nameText,
         item.name,
-        usableTextWidth
+        usableTextWidth,
       );
       const descTruncated = this.applyDescriptionText(
         descText,
         item.description,
         usableTextWidth,
-        maxDescriptionLines
+        maxDescriptionLines,
       );
 
       const iconMarginBottom = item.isEmptyOption ? 0 : layoutSpace.iconGap;
@@ -895,14 +905,14 @@ export class GridSelect extends Phaser.GameObjects.Container {
         0,
         "center",
         { bottom: layoutSpace.labelGap },
-        false
+        false,
       );
       container.add(
         energyText,
         0,
         "center",
         { bottom: layoutSpace.labelGap },
-        false
+        false,
       );
       container.add(descText, 0, "center", 0, false);
       container.add(
@@ -910,37 +920,37 @@ export class GridSelect extends Phaser.GameObjects.Container {
         0,
         "right-top",
         { right: 12, top: 12 },
-        false
+        false,
       );
 
       (container as unknown as Phaser.GameObjects.GameObject).setData("bg", bg);
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "icon",
-        icon
+        icon,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "name",
-        nameText
+        nameText,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "desc",
-        descText
+        descText,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "energy",
-        energyText
+        energyText,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "id",
-        item.id
+        item.id,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "showTooltip",
-        nameTruncated || descTruncated
+        nameTruncated || descTruncated,
       );
       (container as unknown as Phaser.GameObjects.GameObject).setData(
         "cooldown",
-        cooldownText
+        cooldownText,
       );
 
       (
@@ -1047,7 +1057,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
           descText,
           item.description,
           usableTextWidth,
-          maxDescriptionLines
+          maxDescriptionLines,
         )
       : false;
     containerGO.setData("id", item.id);
@@ -1090,15 +1100,15 @@ export class GridSelect extends Phaser.GameObjects.Container {
       cellHeight: number;
       textWidth: number;
       isSelected: boolean;
-    }
+    },
   ) {
     const disabled = config.item.disabled === true;
     const selected = config.isSelected && !disabled;
     const baseColor = selected
       ? CARD_BACKGROUND_SELECTED
       : disabled
-      ? CARD_BACKGROUND_DISABLED
-      : CARD_BACKGROUND_COLOR;
+        ? CARD_BACKGROUND_DISABLED
+        : CARD_BACKGROUND_COLOR;
     config.bg?.setFillStyle?.(baseColor, 1);
     config.bg?.setSize?.(config.cellWidth, config.cellHeight);
     config.bg?.setDisplaySize?.(config.cellWidth, config.cellHeight);
@@ -1108,7 +1118,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     }
     config.nameText?.setColor(disabled ? DISABLED_TEXT_COLOR : "#ffffff");
     config.descText?.setColor(
-      disabled ? DISABLED_TEXT_COLOR : MODAL_TEXT_COLOR
+      disabled ? DISABLED_TEXT_COLOR : MODAL_TEXT_COLOR,
     );
     if (config.energyText) {
       const hasCost =
@@ -1119,7 +1129,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         const label = `Energy: ${config.item.energyCost}`;
         this.applySingleLineText(config.energyText, label, config.textWidth);
         config.energyText.setColor(
-          disabled ? DISABLED_TEXT_COLOR : ENERGY_COST_TEXT_COLOR
+          disabled ? DISABLED_TEXT_COLOR : ENERGY_COST_TEXT_COLOR,
         );
         config.energyText.setVisible(true);
       } else {
@@ -1152,7 +1162,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     target: Phaser.GameObjects.Text,
     content: string | null | undefined,
     maxWidth: number,
-    maxLines: number
+    maxLines: number,
   ): boolean {
     const textValue = typeof content === "string" ? content : "";
     const hasContent = textValue.trim().length > 0;
@@ -1274,7 +1284,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     this.background.setStrokeStyle?.(2, COLLAPSED_BORDER_COLOR, 1);
     this.icon.setAlpha(this.enabled ? 1 : 0.6);
     this.label.setColor(
-      this.enabled ? this.labelActiveColor : DISABLED_TEXT_COLOR
+      this.enabled ? this.labelActiveColor : DISABLED_TEXT_COLOR,
     );
     if (!this.enabled) {
       this.scene.input.setDefaultCursor("default");
@@ -1285,7 +1295,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     const style = target.style as Phaser.GameObjects.TextStyle & {
       syncFont?: (
         canvas: HTMLCanvasElement,
-        context: CanvasRenderingContext2D
+        context: CanvasRenderingContext2D,
       ) => void;
     };
     const context = target.context;
@@ -1307,7 +1317,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
   private ellipsize(
     content: string,
     target: Phaser.GameObjects.Text,
-    maxWidth: number
+    maxWidth: number,
   ) {
     const ellipsis = "…";
     const base = content.trimEnd();
@@ -1331,7 +1341,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
   private applySingleLineText(
     target: Phaser.GameObjects.Text,
     content: string,
-    maxWidth: number
+    maxWidth: number,
   ): boolean {
     const trimmed = content.trimEnd();
     const display = this.ellipsize(trimmed, target, maxWidth);
@@ -1345,7 +1355,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
     target: Phaser.GameObjects.Text,
     content: string,
     maxWidth: number,
-    maxLines: number
+    maxLines: number,
   ): boolean {
     target.setWordWrapWidth(maxWidth, true);
     target.setText(content);

--- a/client/src/ui/GridSelect.ts
+++ b/client/src/ui/GridSelect.ts
@@ -449,6 +449,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       .rectangle(0, 0, width, height, 0x020617, 0.75)
       .setOrigin(0, 0)
       .setInteractive();
+    let pointerDownOnCover = false;
     cover.on(
       Phaser.Input.Events.POINTER_DOWN,
       (
@@ -457,6 +458,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
         _y: number,
         event: Phaser.Types.Input.EventData
       ) => {
+        pointerDownOnCover = true;
         event.stopPropagation();
       }
     );
@@ -480,6 +482,10 @@ export class GridSelect extends Phaser.GameObjects.Container {
         event: Phaser.Types.Input.EventData
       ) => {
         event.stopPropagation();
+        if (!pointerDownOnCover) {
+          return;
+        }
+        pointerDownOnCover = false;
         this.tooltip?.hide();
         this.closeModal();
       }
@@ -514,6 +520,23 @@ export class GridSelect extends Phaser.GameObjects.Container {
       MODAL_BACKGROUND_COLOR
     );
     modal.addBackground(background);
+    const backgroundGO = background as unknown as Phaser.GameObjects.GameObject & {
+      setInteractive?: () => Phaser.GameObjects.GameObject;
+      on?: (event: string, handler: (...args: unknown[]) => void) => void;
+    };
+    backgroundGO.setInteractive?.();
+    backgroundGO.on?.(
+      Phaser.Input.Events.POINTER_DOWN,
+      (_pointer: unknown, _x: unknown, _y: unknown, event: Phaser.Types.Input.EventData) => {
+        event.stopPropagation();
+      }
+    );
+    backgroundGO.on?.(
+      Phaser.Input.Events.POINTER_UP,
+      (_pointer: unknown, _x: unknown, _y: unknown, event: Phaser.Types.Input.EventData) => {
+        event.stopPropagation();
+      }
+    );
 
     const header = scene.add
       .text(0, 0, this.modalTitle, {
@@ -570,6 +593,12 @@ export class GridSelect extends Phaser.GameObjects.Container {
     this.ensureTooltip();
     this.overlay = overlay;
     this.gridTable = gridTable;
+    scene.time.delayedCall(0, () => {
+      if (this.gridTable) {
+        this.gridTable.refresh?.();
+        this.gridTable.layout?.();
+      }
+    });
   }
 
   private closeModal(forceDestroy = false) {
@@ -634,7 +663,7 @@ export class GridSelect extends Phaser.GameObjects.Container {
       },
       mouseWheelScroller: {
         focus: true,
-        speed: 0.3,
+        speed: 1.5,
       },
       space: {
         left: 0,

--- a/client/src/ui/GridSelect.ts
+++ b/client/src/ui/GridSelect.ts
@@ -520,20 +520,17 @@ export class GridSelect extends Phaser.GameObjects.Container {
       MODAL_BACKGROUND_COLOR
     );
     modal.addBackground(background);
-    const backgroundGO = background as unknown as Phaser.GameObjects.GameObject & {
-      setInteractive?: () => Phaser.GameObjects.GameObject;
-      on?: (event: string, handler: (...args: unknown[]) => void) => void;
-    };
-    backgroundGO.setInteractive?.();
-    backgroundGO.on?.(
+    const backgroundGO = background as unknown as Phaser.GameObjects.GameObject;
+    backgroundGO.setInteractive();
+    backgroundGO.on(
       Phaser.Input.Events.POINTER_DOWN,
-      (_pointer: unknown, _x: unknown, _y: unknown, event: Phaser.Types.Input.EventData) => {
+      (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: Phaser.Types.Input.EventData) => {
         event.stopPropagation();
       }
     );
-    backgroundGO.on?.(
+    backgroundGO.on(
       Phaser.Input.Events.POINTER_UP,
-      (_pointer: unknown, _x: unknown, _y: unknown, event: Phaser.Types.Input.EventData) => {
+      (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: Phaser.Types.Input.EventData) => {
         event.stopPropagation();
       }
     );


### PR DESCRIPTION
## Planned issue
GUI/action selector related fixes:
- Unread chat visual effect in chat tab
- First scroll in actions selector does not show text
- Incorrect close behavior when dragging/releasing outside scrollbar
- Closing when clicking in the select action modal any title/borders
- Drag scrolling in the select action modal also moves the map
- Mousewheel zoom in the map also scrolls the character tab
- Increase scrollwheel step of the select action modal
- Prevent click-through on ready button when character tab list is scrolled at bottom

## Status
Planning PR only. No implementation in this branch yet.