### PR TITLE
fix: action targeting scope to current cell and range rules

### DIFF
--- a/client/src/scenes/GameScene.ts
+++ b/client/src/scenes/GameScene.ts
@@ -110,6 +110,8 @@ export class GameScene extends Phaser.Scene {
   private currentPlayerSkin: import("@shared").Skin | null = null;
   private playerSkinMap = new Map<string, import("@shared").Skin>();
   private accountService: AccountService | null = null;
+  private playerViewRange: number = 0;
+  private playerCoordForTinting: Axial | null = null;
   private readonly turnAdvancedHandler = (
     payload: TurnAdvancedMessagePayload,
   ) => {
@@ -426,6 +428,68 @@ export class GameScene extends Phaser.Scene {
     return generated.map;
   }
 
+  private getCurrentPlayerViewRange(): number {
+    if (!this.currentMatch || !this.currentUserId) {
+      return 0;
+    }
+    const character = this.currentMatch.playerCharacters?.[this.currentUserId];
+    const viewRange = character?.stats?.baseViewRange;
+    return typeof viewRange === "number" && isFinite(viewRange)
+      ? Math.max(0, Math.floor(viewRange))
+      : 0;
+  }
+
+  private isOutOfViewRange(coord: Axial): boolean {
+    if (!this.playerCoordForTinting) {
+      return false;
+    }
+    const distance = this.axialDistance(this.playerCoordForTinting, coord);
+    return distance > this.playerViewRange;
+  }
+
+  private updateTileTintState(
+    image: Phaser.GameObjects.Image,
+    tile: HexTile,
+    options: {
+      isLocationSelectionActive?: boolean;
+      isInActionRange?: boolean;
+      isHovered?: boolean;
+    } = {},
+  ): void {
+    const isOutOfRange = this.isOutOfViewRange(tile.coord);
+    const dimTint = 0x666666; // Darker gray for out-of-view tiles
+    const { isLocationSelectionActive, isInActionRange, isHovered } = options;
+
+    // Base: apply dim tint if out of view range
+    if (isOutOfRange) {
+      image.setTint(dimTint);
+      image.setAlpha(1);
+    } else {
+      image.clearTint();
+      image.setAlpha(1);
+    }
+
+    // If location selection is active, apply selection tints on top of dimness
+    if (isLocationSelectionActive) {
+      if (isInActionRange) {
+        image.setTint(isOutOfRange ? dimTint | 0x7dd3fc : 0x7dd3fc);
+      } else {
+        image.setTint(isOutOfRange ? dimTint | 0x334155 : 0x334155);
+        image.setAlpha(0.8);
+      }
+    }
+
+    // Hover state overrides selection tints
+    if (isHovered) {
+      const hoverTint = isInActionRange ? 0xfacc15 : 0xfb7185;
+      image.setTint(hoverTint);
+      image.setAlpha(1);
+      image.setScale(1.03);
+    } else {
+      image.setScale(1);
+    }
+  }
+
   private renderMap(map: GameMap) {
     const tileW = GameScene.TILE_WIDTH;
     const tileH = GameScene.TILE_HEIGHT;
@@ -435,6 +499,11 @@ export class GameScene extends Phaser.Scene {
     const sprites: Phaser.GameObjects.Image[] = [];
     this.tilePositions = {};
     this.mapTileSprites = [];
+
+    const playerCoord = this.getCurrentPlayerCoord();
+    const viewRange = this.getCurrentPlayerViewRange();
+    this.playerCoordForTinting = playerCoord;
+    this.playerViewRange = viewRange;
 
     for (const snapshot of map.tiles) {
       let tile: HexTile;
@@ -455,6 +524,10 @@ export class GameScene extends Phaser.Scene {
       const y = row * dy + tileH;
       const img = this.add.image(x, y, "hex", frame);
       img.setData("tile", tile);
+
+      // Apply base tint (view range dimming)
+      this.updateTileTintState(img, tile);
+
       img.setInteractive({ useHandCursor: false });
       img.on(Phaser.Input.Events.POINTER_OVER, () => {
         this.setLocationSelectionHoveredTile(tile.id);
@@ -629,6 +702,8 @@ export class GameScene extends Phaser.Scene {
         this.playerNameLabels.delete(playerId);
       }
     }
+    // Ensure tile tinting reflects the current player's position/view
+    this.refreshAllTileTints();
   }
 
   private renderItems(map: GameMap) {
@@ -1946,30 +2021,48 @@ export class GameScene extends Phaser.Scene {
   }
 
   private refreshLocationSelectionVisuals() {
-    const active = this.locationSelectionActive && !!this.locationSelectionActionId;
+    const active =
+      this.locationSelectionActive && !!this.locationSelectionActionId;
     const actionId = this.locationSelectionActionId;
     const hovered = this.locationSelectionHoveredTileId;
     for (const entry of this.mapTileSprites) {
       const { tile, image } = entry;
-      image.clearTint();
-      image.setScale(1);
-      image.setAlpha(1);
-      if (!active || !actionId) {
-        continue;
-      }
-      const inRange = this.isLocationInRange(actionId, tile.coord);
-      if (inRange) {
-        image.setTint(0x7dd3fc);
-      } else {
-        image.setTint(0x334155);
-        image.setAlpha(0.8);
-      }
-      if (hovered === tile.id) {
-        image.setTint(inRange ? 0xfacc15 : 0xfb7185);
-        image.setScale(1.03);
-      }
+      const isHovered = hovered === tile.id;
+      const isInRange =
+        active && actionId
+          ? this.isLocationInRange(actionId, tile.coord)
+          : false;
+      this.updateTileTintState(image, tile, {
+        isLocationSelectionActive: active,
+        isInActionRange: isInRange,
+        isHovered,
+      });
     }
     this.updateLocationSelectionHoverText();
+  }
+
+  private refreshAllTileTints(): void {
+    // Update stored player coord/range then refresh all tile tints
+    this.playerCoordForTinting = this.getCurrentPlayerCoord();
+    this.playerViewRange = this.getCurrentPlayerViewRange();
+    const active =
+      this.locationSelectionActive && !!this.locationSelectionActionId;
+    const actionId = this.locationSelectionActionId;
+    const hovered = this.locationSelectionHoveredTileId;
+
+    for (const entry of this.mapTileSprites) {
+      const { tile, image } = entry;
+      const isHovered = hovered === tile.id;
+      const isInRange =
+        active && actionId
+          ? this.isLocationInRange(actionId, tile.coord)
+          : false;
+      this.updateTileTintState(image, tile, {
+        isLocationSelectionActive: active,
+        isInActionRange: isInRange,
+        isHovered,
+      });
+    }
   }
 
   private updateLocationSelectionHoverText() {
@@ -2006,7 +2099,10 @@ export class GameScene extends Phaser.Scene {
     );
     this.locationSelectionHoverText.setPosition(
       image.x - this.locationSelectionHoverText.width / 2,
-      image.y - image.displayHeight / 2 - this.locationSelectionHoverText.height - 8,
+      image.y -
+        image.displayHeight / 2 -
+        this.locationSelectionHoverText.height -
+        8,
     );
     this.locationSelectionHoverText.setVisible(true);
   }

--- a/client/src/ui/CharacterPanel.ts
+++ b/client/src/ui/CharacterPanel.ts
@@ -1795,9 +1795,6 @@ export class CharacterPanel extends Phaser.GameObjects.Container {
           iconScale: sprite.iconScale,
         });
       };
-      if (Array.isArray(match.players)) {
-        match.players.forEach((id) => pushOption(id));
-      }
       if (match.playerCharacters) {
         Object.keys(match.playerCharacters).forEach((id) => pushOption(id));
       }

--- a/server/modules/src/match/actions/scare.ts
+++ b/server/modules/src/match/actions/scare.ts
@@ -47,8 +47,8 @@ export function executeScareAction(
       ? collectTargets(actionId, participant, match, {
           allowMultiple: false,
           filter: (candidate) =>
-            candidate.distance === SAME_CELL_DISTANCE &&
-            !isTargetProtected(candidate.character),
+            !isTargetProtected(candidate.character) &&
+            candidate.distance === SAME_CELL_DISTANCE,
         })
       : [];
     clearPlanByKey(participant.character, participant.planKey);

--- a/server/modules/src/match/actions/scare.ts
+++ b/server/modules/src/match/actions/scare.ts
@@ -15,6 +15,8 @@ import {
 } from "./utils";
 import { collectTargets } from "./targeting";
 
+const SAME_CELL_DISTANCE = 0;
+
 function reduceEnergy(character: PlayerCharacter, amount: number): number {
   if (!character.stats?.energy) {
     return 0;
@@ -45,7 +47,8 @@ export function executeScareAction(
       ? collectTargets(actionId, participant, match, {
           allowMultiple: false,
           filter: (candidate) =>
-            candidate.distance === 0 && !isTargetProtected(candidate.character),
+            candidate.distance === SAME_CELL_DISTANCE &&
+            !isTargetProtected(candidate.character),
         })
       : [];
     clearPlanByKey(participant.character, participant.planKey);

--- a/server/modules/src/match/actions/scare.ts
+++ b/server/modules/src/match/actions/scare.ts
@@ -15,7 +15,7 @@ import {
 } from "./utils";
 import { collectTargets } from "./targeting";
 
-const SAME_CELL_DISTANCE = 0;
+const CURRENT_CELL_DISTANCE = 0;
 
 function reduceEnergy(character: PlayerCharacter, amount: number): number {
   if (!character.stats?.energy) {
@@ -48,7 +48,7 @@ export function executeScareAction(
           allowMultiple: false,
           filter: (candidate) =>
             !isTargetProtected(candidate.character) &&
-            candidate.distance === SAME_CELL_DISTANCE,
+            candidate.distance === CURRENT_CELL_DISTANCE,
         })
       : [];
     clearPlanByKey(participant.character, participant.planKey);

--- a/server/modules/src/match/actions/scare.ts
+++ b/server/modules/src/match/actions/scare.ts
@@ -44,7 +44,8 @@ export function executeScareAction(
     const selection = origin
       ? collectTargets(actionId, participant, match, {
           allowMultiple: false,
-          filter: (candidate) => !isTargetProtected(candidate.character),
+          filter: (candidate) =>
+            candidate.distance === 0 && !isTargetProtected(candidate.character),
         })
       : [];
     clearPlanByKey(participant.character, participant.planKey);

--- a/server/modules/src/match/actions/targeting.ts
+++ b/server/modules/src/match/actions/targeting.ts
@@ -25,7 +25,7 @@ function coordsEqual(a: Axial | undefined, b: Axial | undefined): boolean {
 
 function pushUnique(
   target: TargetCandidate[],
-  candidate: TargetCandidate
+  candidate: TargetCandidate,
 ): void {
   if (target.some((entry) => entry.id === candidate.id)) {
     return;
@@ -35,7 +35,7 @@ function pushUnique(
 
 function findCandidate(
   list: TargetCandidate[],
-  id: string
+  id: string,
 ): TargetCandidate | undefined {
   for (const entry of list) {
     if (entry.id === id) {
@@ -52,8 +52,12 @@ export function collectTargets(
   options: CollectTargetsOptions = {}
 ): TargetCandidate[] {
   const definition = ActionLibrary[actionId];
-  const allowed =
+  let allowed =
     definition?.range && definition.range.length > 0 ? definition.range : [0];
+  if (actionId === "scare") {
+    allowed = [0];
+  }
+
   const actorCoord = participant.character.position?.coord;
   if (!actorCoord) {
     return [];

--- a/server/modules/src/match/async_turn/signal.ts
+++ b/server/modules/src/match/async_turn/signal.ts
@@ -16,6 +16,7 @@ import { tailorReplayEvents } from "../replay/tailorReplay";
 import {
   tailorMapForCharacter,
   tailorMatchItemsForCharacter,
+  tailorPlayerCharactersForViewer,
 } from "../../utils/matchView";
 
 export const asyncTurnMatchSignal: nkruntime.MatchSignalFunction<AsyncTurnState> =
@@ -221,6 +222,10 @@ export const asyncTurnMatchSignal: nkruntime.MatchSignalFunction<AsyncTurnState>
               const payload = JSON.stringify({
                 ...payloadBase,
                 replay: tailored,
+                playerCharacters: tailorPlayerCharactersForViewer(
+                  msg.playerCharacters,
+                  playerId,
+                ),
                 map: tailorMapForCharacter(
                   msg.map,
                   msg.playerCharacters?.[playerId] ?? null,

--- a/server/modules/src/rpc/updateReadyState.ts
+++ b/server/modules/src/rpc/updateReadyState.ts
@@ -9,6 +9,7 @@ import type { AdvanceTurnResult } from "../match/advanceTurn";
 import {
   tailorMapForCharacter,
   tailorMatchItemsForCharacter,
+  tailorPlayerCharactersForViewer,
 } from "../utils/matchView";
 import { isCharacterIncapacitated } from "../utils/playerCharacter";
 import { resolveTurnForMatch } from "../match/turnResolution";
@@ -190,7 +191,10 @@ export function updateReadyStateRpc(
     turn: match.current_turn,
     readyStates: match.readyStates,
     advanced,
-    playerCharacters: match.playerCharacters,
+    playerCharacters: tailorPlayerCharactersForViewer(
+      match.playerCharacters,
+      ctx.userId,
+    ),
     map: tailorMapForCharacter(match.map, viewerCharacter),
     items: tailorMatchItemsForCharacter(match.items, viewerCharacter),
   };

--- a/server/modules/src/utils/matchView.ts
+++ b/server/modules/src/utils/matchView.ts
@@ -149,8 +149,7 @@ export function tailorMatchForPlayer(
   );
   return {
     ...match,
-    playerCharacters:
-      playerCharacters ?? ({} as Record<string, PlayerCharacter>),
+    playerCharacters: playerCharacters ?? {},
     map,
     items,
   };

--- a/server/modules/src/utils/matchView.ts
+++ b/server/modules/src/utils/matchView.ts
@@ -1,5 +1,6 @@
 import type { GameMap, MatchItemRecord, PlayerCharacter } from "@shared";
 import type { MatchRecord } from "../models/types";
+import { axialDistance } from "./location";
 
 type FoundLookup = Record<string, true>;
 
@@ -64,6 +65,57 @@ function filterItemsByFoundLookup(
   return filtered.map((item) => ({ ...item }));
 }
 
+function resolveViewRange(
+  character: PlayerCharacter | undefined | null
+): number {
+  const raw = character?.stats?.baseViewRange;
+  if (typeof raw !== "number" || !isFinite(raw)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(raw));
+}
+
+export function tailorPlayerCharactersForViewer(
+  playerCharacters: Record<string, PlayerCharacter> | undefined,
+  viewerId: string | undefined | null
+): Record<string, PlayerCharacter> | undefined {
+  if (!playerCharacters) {
+    return playerCharacters;
+  }
+  const viewerKey = typeof viewerId === "string" ? viewerId : "";
+  if (!viewerKey) {
+    return { ...playerCharacters };
+  }
+  const viewer = playerCharacters[viewerKey];
+  if (!viewer) {
+    return { ...playerCharacters };
+  }
+  const viewerCoord = viewer.position?.coord;
+  const viewRange = resolveViewRange(viewer);
+  const filtered: Record<string, PlayerCharacter> = {};
+  for (const id in playerCharacters) {
+    if (!Object.prototype.hasOwnProperty.call(playerCharacters, id)) {
+      continue;
+    }
+    const candidate = playerCharacters[id];
+    if (id === viewerKey) {
+      filtered[id] = candidate;
+      continue;
+    }
+    if (!viewerCoord) {
+      continue;
+    }
+    const candidateCoord = candidate?.position?.coord;
+    if (!candidateCoord) {
+      continue;
+    }
+    if (axialDistance(viewerCoord, candidateCoord) <= viewRange) {
+      filtered[id] = candidate;
+    }
+  }
+  return filtered;
+}
+
 export function tailorMapForCharacter(
   map: GameMap | undefined,
   character: PlayerCharacter | undefined | null
@@ -91,8 +143,14 @@ export function tailorMatchForPlayer(
   const found = buildFoundItemLookup(character);
   const map = filterMapByFoundLookup(match.map, found);
   const items = filterItemsByFoundLookup(match.items, found);
+  const playerCharacters = tailorPlayerCharactersForViewer(
+    match.playerCharacters,
+    playerId
+  );
   return {
     ...match,
+    playerCharacters:
+      playerCharacters ?? ({} as Record<string, PlayerCharacter>),
     map,
     items,
   };

--- a/server/modules/src/utils/matchView.ts
+++ b/server/modules/src/utils/matchView.ts
@@ -65,7 +65,7 @@ function filterItemsByFoundLookup(
   return filtered.map((item) => ({ ...item }));
 }
 
-function getCharacterViewRange(
+function computeViewRange(
   character: PlayerCharacter | undefined | null
 ): number {
   const raw = character?.stats?.baseViewRange;
@@ -91,7 +91,7 @@ export function tailorPlayerCharactersForViewer(
     return { ...playerCharacters };
   }
   const viewerCoord = viewer.position?.coord;
-  const viewRange = getCharacterViewRange(viewer);
+  const viewRange = computeViewRange(viewer);
   const filtered: Record<string, PlayerCharacter> = {};
   for (const id in playerCharacters) {
     if (!Object.prototype.hasOwnProperty.call(playerCharacters, id)) {

--- a/server/modules/src/utils/matchView.ts
+++ b/server/modules/src/utils/matchView.ts
@@ -65,7 +65,7 @@ function filterItemsByFoundLookup(
   return filtered.map((item) => ({ ...item }));
 }
 
-function resolveViewRange(
+function getCharacterViewRange(
   character: PlayerCharacter | undefined | null
 ): number {
   const raw = character?.stats?.baseViewRange;
@@ -91,7 +91,7 @@ export function tailorPlayerCharactersForViewer(
     return { ...playerCharacters };
   }
   const viewerCoord = viewer.position?.coord;
-  const viewRange = resolveViewRange(viewer);
+  const viewRange = getCharacterViewRange(viewer);
   const filtered: Record<string, PlayerCharacter> = {};
   for (const id in playerCharacters) {
     if (!Object.prototype.hasOwnProperty.call(playerCharacters, id)) {


### PR DESCRIPTION
## Planned issue
- Only view players in current cell(like a fog of war), using the variable of the character player stats baseViewRange, 0 means only current cell
- The scare action has a bug, it can scare people to the range defined in range property in actionLibrary, but the players can affect can only be in the current cell, not looking at the range property
- For scare with no explicit target, auto select only players in current cell

## Status
Planning PR only. No implementation in this branch yet.